### PR TITLE
feat: 添加购买确认界面，防止误操作

### DIFF
--- a/src/main/java/cat/nyaa/hmarket/ui/HMarketViewServer.java
+++ b/src/main/java/cat/nyaa/hmarket/ui/HMarketViewServer.java
@@ -1,6 +1,7 @@
 package cat.nyaa.hmarket.ui;
 
 import cat.nyaa.hmarket.HMI18n;
+import cat.nyaa.hmarket.ui.data.ShopItemDataUtils;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -20,6 +21,7 @@ public class HMarketViewServer implements Listener {
     private final JavaPlugin pluginInstance;
 
     private final Map<UUID, HmarketShopView> viewMap = new HashMap<>();
+    private final Map<UUID, HmarketConfirmPurchaseView> confirmViewMap = new HashMap<>();
     private final Set<UUID> interactedPlayers = new HashSet<>();
 
     private final BukkitTask resetTask;
@@ -35,7 +37,13 @@ public class HMarketViewServer implements Listener {
     }
 
     public void createViewForPlayer(Player player, UUID marketId, Component title) {
+        confirmViewMap.remove(player.getUniqueId());
         viewMap.put(player.getUniqueId(), new HmarketShopView(player, marketId, title));
+    }
+
+    public void openConfirmViewForPlayer(Player player, HmarketConfirmPurchaseView confirmView) {
+        confirmViewMap.put(player.getUniqueId(), confirmView);
+        player.openInventory(confirmView.getUi());
     }
 
     public void destrutor() {
@@ -56,19 +64,50 @@ public class HMarketViewServer implements Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
-        if (event.getClickedInventory() == null
-                || !viewMap.containsKey(event.getWhoClicked().getUniqueId()))
+        if (event.getClickedInventory() == null)
             return;
-        if (event.getInventory() != viewMap.get(event.getWhoClicked().getUniqueId()).getUi())
+        var playerId = event.getWhoClicked().getUniqueId();
+
+        // Handle confirmation view clicks first
+        if (confirmViewMap.containsKey(playerId)) {
+            var confirmView = confirmViewMap.get(playerId);
+            if (event.getInventory() == confirmView.getUi()) {
+                event.setCancelled(true);
+                var item = event.getCurrentItem();
+                if (item == null || item.getType().isAir()) return;
+                if (interactedPlayers.contains(playerId))
+                    return;
+                confirmView.onClick((Player) event.getWhoClicked(), item, event.getSlot());
+                interactedPlayers.add(playerId);
+                return;
+            }
+        }
+
+        // Handle shop view clicks
+        if (!viewMap.containsKey(playerId))
             return;
-        if (event.getClickedInventory() == viewMap.get(event.getWhoClicked().getUniqueId()).getUi()) {
+        if (event.getInventory() != viewMap.get(playerId).getUi())
+            return;
+        if (event.getClickedInventory() == viewMap.get(playerId).getUi()) {
             event.setCancelled(true);
             var item = event.getCurrentItem();
             if (item == null || item.getType().isAir()) return;
-            if (interactedPlayers.contains(event.getWhoClicked().getUniqueId()))
+            if (interactedPlayers.contains(playerId))
                 return; //can interact with ui only once per tick
-            viewMap.get(event.getWhoClicked().getUniqueId()).onClick((Player) event.getWhoClicked(), event.getAction(), item, event.getSlot());
-            interactedPlayers.add(event.getWhoClicked().getUniqueId());
+            var shopView = viewMap.get(playerId);
+            if (item.equals(HmarketShopView.iconNextPage)) {
+                shopView.onPageChange(event.getAction(), item, event.getSlot());
+            } else if (item.equals(HmarketShopView.iconPrevPage)) {
+                shopView.onPageChange(event.getAction(), item, event.getSlot());
+            } else if (item.equals(HmarketShopView.iconRefresh)) {
+                shopView.onRefresh(event.getAction(), item, event.getSlot());
+            } else if (ShopItemDataUtils.checkIfIsWindowedItem(item)) {
+                var confirmView = shopView.createConfirmView((Player) event.getWhoClicked(), event.getAction(), item, event.getSlot());
+                if (confirmView != null) {
+                    openConfirmViewForPlayer((Player) event.getWhoClicked(), confirmView);
+                }
+            }
+            interactedPlayers.add(playerId);
         }
         if (event.getClickedInventory() == event.getWhoClicked().getInventory()) {
             if (event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
@@ -96,14 +135,26 @@ public class HMarketViewServer implements Listener {
 
     @EventHandler
     public void onCloseInventory(InventoryCloseEvent event) {
-        if (viewMap.containsKey(event.getPlayer().getUniqueId()))
-            if (event.getInventory() == viewMap.get(event.getPlayer().getUniqueId()).getUi()) {
-                viewMap.remove(event.getPlayer().getUniqueId());
+        var playerId = event.getPlayer().getUniqueId();
+        if (confirmViewMap.containsKey(playerId)) {
+            if (event.getInventory() == confirmViewMap.get(playerId).getUi()) {
+                confirmViewMap.remove(playerId);
+                // When closed via X button, return to shop view
+                if (viewMap.containsKey(playerId)) {
+                    event.getPlayer().openInventory(viewMap.get(playerId).getUi());
+                }
+            }
+            return;
+        }
+        if (viewMap.containsKey(playerId))
+            if (event.getInventory() == viewMap.get(playerId).getUi()) {
+                viewMap.remove(playerId);
             }
     }
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
+        confirmViewMap.remove(event.getPlayer().getUniqueId());
         viewMap.remove(event.getPlayer().getUniqueId());
     }
 

--- a/src/main/java/cat/nyaa/hmarket/ui/HmarketShopView.java
+++ b/src/main/java/cat/nyaa/hmarket/ui/HmarketShopView.java
@@ -23,9 +23,9 @@ import static cat.nyaa.hmarket.api.data.MarketBuyResult.MarketBuyStatus.WITHDRAW
 
 public class HmarketShopView {
     private static final ItemStack iconLoading;
-    private static final ItemStack iconRefresh;
-    private static final ItemStack iconNextPage;
-    private static final ItemStack iconPrevPage;
+    static final ItemStack iconRefresh;
+    static final ItemStack iconNextPage;
+    static final ItemStack iconPrevPage;
     private static final ItemStack iconNotAvail; // which is bought by others
 
     private static final ItemStack iconEmptyStore;
@@ -93,12 +93,14 @@ public class HmarketShopView {
         iconError.setItemMeta(meta);
     }
 
-    private final IMarketAPI api;
+       private final IMarketAPI api;
     private final Inventory ui;
     private final Player viewOwner;
     private final List<ItemStack> items = new ArrayList<>();
     private final UUID viewShopID;
     private int currentPage = 1;
+    private ItemStack pendingItemStack;
+    private int pendingSlot;
 
 
     public HmarketShopView(Player viewOwner, UUID shopUniqueID, Component title) {
@@ -139,67 +141,57 @@ public class HmarketShopView {
         return currentPage > 1;
     }
 
-    public void onClick(Player player, InventoryAction action, ItemStack itemStack, int slot) {
-        if (itemStack.equals(iconNextPage)) {
-            if (hasNextPage())
-                currentPage++;
-            renderPage(currentPage);
-        } else if (itemStack.equals(iconPrevPage)) {
-            if (hasPrevPage())
-                currentPage--;
-            renderPage(currentPage);
-        } else if (itemStack.equals(iconRefresh)) {
-            reloadShopItems(viewShopID);
-        } else if (ShopItemDataUtils.checkIfIsWindowedItem(itemStack)) {
-            //buy item by checking action
-            //click to buy 1
-            //right click to buy a half
-            //shift click to buy all
-            final int amount = switch (action) {
-                case PICKUP_ALL -> 1;
-                case PICKUP_HALF -> {
-                    var half = itemStack.getAmount() / 2;
-                    yield half * 2 == itemStack.getAmount() ? half : half + 1;
+    public HmarketConfirmPurchaseView createConfirmView(Player player, InventoryAction action, ItemStack itemStack, int slot) {
+        //click to buy 1
+        //right click to buy a half
+        //shift click to buy all
+        final int amount = switch (action) {
+            case PICKUP_ALL -> 1;
+            case PICKUP_HALF -> {
+                var half = itemStack.getAmount() / 2;
+                yield half * 2 == itemStack.getAmount() ? half : half + 1;
+            }
+            case MOVE_TO_OTHER_INVENTORY -> itemStack.getAmount();
+            default -> -1;
+        };
+        if (amount == -1)
+            return null;
+        int marketItemId = ShopItemDataUtils.getMarketItemIDFromItemStack(itemStack);
+        pendingItemStack = itemStack.clone();
+        pendingSlot = slot;
+        ui.setItem(slot, iconPending);
+        return new HmarketConfirmPurchaseView(player, this, viewShopID, marketItemId, amount, slot, itemStack);
+    }
+
+    public void returnFromConfirmation(int shopSlot, ItemStack originalItem) {
+        setItemInCurrentPage(shopSlot, originalItem);
+        renderPage(currentPage);
+    }
+
+    public void onPurchaseResult(MarketBuyResult result, int shopSlot, int amount, ItemStack itemStack) {
+        switch (result.status()) {
+            case WITHDRAW_SUCCESS, SUCCESS -> {
+                if (amount == itemStack.getAmount()) {
+                    setItemInCurrentPage(shopSlot, result.status() == WITHDRAW_SUCCESS ? iconWithdrawn : iconPurchased);
+                } else {
+                    itemStack.setAmount(itemStack.getAmount() - amount);
+                    setItemInCurrentPage(shopSlot, itemStack);
                 }
-                case MOVE_TO_OTHER_INVENTORY -> itemStack.getAmount();
-                default -> -1;
-            };
-            if (amount == -1)
-                return;
-            ui.setItem(slot, iconPending);
-            Bukkit.getScheduler().runTaskAsynchronously(Hmarket.getInstance(), () -> {
-                MarketBuyResult result;
-                try {
-                    result = api.buy(player, viewShopID, ShopItemDataUtils.getMarketItemIDFromItemStack(itemStack), amount).get();
-                } catch (InterruptedException | ExecutionException e) {
-                    closeUiIfErrorOccurred(e);
-                    return;
+            }
+            case OUT_OF_STOCK, ITEM_NOT_FOUND -> {
+                setItemInCurrentPage(shopSlot, iconNotAvail);
+            }
+            case NOT_ENOUGH_MONEY, TASK_FAILED, TRANSACTION_ERROR, WRONG_MARKET, CANNOT_BUY_ITEM -> {
+                var icon = iconError.clone();
+                if (result.status() == NOT_ENOUGH_MONEY) {
+                    icon.lore(List.of(HMI18n.format("info.ui.market.not_enough_money")));
+                } else {
+                    icon.lore(List.of(HMI18n.format("info.ui.element.action_needed_description", result.status())));
                 }
-                switch (result.status()) {
-                    case WITHDRAW_SUCCESS, SUCCESS -> {
-                        if (amount == itemStack.getAmount()) {
-                            setItemInCurrentPage(slot, result.status() == WITHDRAW_SUCCESS ? iconWithdrawn : iconPurchased);
-                        } else {
-                            itemStack.setAmount(itemStack.getAmount() - amount);
-                            setItemInCurrentPage(slot, itemStack);
-                        }
-                    }
-                    case OUT_OF_STOCK, ITEM_NOT_FOUND -> {
-                        setItemInCurrentPage(slot, iconNotAvail);
-                    }
-                    case NOT_ENOUGH_MONEY, TASK_FAILED, TRANSACTION_ERROR, WRONG_MARKET, CANNOT_BUY_ITEM -> {
-                        var icon = iconError.clone();
-                        if (result.status() == NOT_ENOUGH_MONEY) {
-                            icon.lore(List.of(HMI18n.format("info.ui.market.not_enough_money")));
-                        } else {
-                            icon.lore(List.of(HMI18n.format("info.ui.element.action_needed_description", result.status())));
-                        }
-                        setItemInCurrentPage(slot, icon);
-                    }
-                }
-                renderPage(currentPage);
-            });
+                setItemInCurrentPage(shopSlot, icon);
+            }
         }
+        renderPage(currentPage);
     }
 
     private void setItemInCurrentPage(int slot, ItemStack itemStack) {
@@ -240,6 +232,22 @@ public class HmarketShopView {
 
     public Inventory getUi() {
         return ui;
+    }
+
+    public void onPageChange(InventoryAction action, ItemStack itemStack, int slot) {
+        if (itemStack.equals(iconNextPage)) {
+            if (hasNextPage())
+                currentPage++;
+            renderPage(currentPage);
+        } else if (itemStack.equals(iconPrevPage)) {
+            if (hasPrevPage())
+                currentPage--;
+            renderPage(currentPage);
+        }
+    }
+
+    public void onRefresh(InventoryAction action, ItemStack itemStack, int slot) {
+        reloadShopItems(viewShopID);
     }
 
 }

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -38,6 +38,7 @@ info:
       shop:
         system: "&8G&7l&fobal Store"
         user: "&8%s&7's &fsign store"
+      confirm_purchase: "&8Confirm Purchase"
     element:
         loading: "&fLoading..."
         loading_description: "&7Please wait for a while..."
@@ -57,6 +58,11 @@ info:
         withdrawn_description: "&7You have withdrawn this item"
         action_needed: "&fError"
         action_needed_description: "&7Failed to buy. Reason: %s"
+        confirm: "&aConfirm"
+        confirm_description: "&7Click to confirm purchase"
+        cancel: "&cCancel"
+        cancel_description: "&7Click to cancel purchase"
+        purchase_amount: "&ePurchasing: x%s"
     item:
       buy_item: "Click to buy item"
       tax: "tax: %s%%, price including tax: %s"


### PR DESCRIPTION
  - 新增 `HmarketConfirmPurchaseView` 确认购买界面类
  - 玩家点击商品后弹出确认窗口，显示购买数量
  - 支持确认/取消操作，取消后返回商店界面
  - 购买成功后自动刷新并返回商店界面

?! 谁破防了 ?!